### PR TITLE
Parallel Processing

### DIFF
--- a/inst/extdata/plumber.R
+++ b/inst/extdata/plumber.R
@@ -27,22 +27,22 @@ function(link, service, model_name, vocoder_name){
   tmp_video <- tempfile(fileext = ".mp4")
 
   future::future({
-  # Speaker Notes
-  pptx_path <- gsplyr::download(link, type = "pptx")
-  pptx_notes_vector <- ptplyr::extract_notes(pptx_path)
-  # Images
-  pdf_path <- gsplyr::download(link, type = "pdf")
-  image_path <- ptplyr::convert_pdf_png(pdf_path)
+    # Speaker Notes
+    pptx_path <- gsplyr::download(link, type = "pptx")
+    pptx_notes_vector <- ptplyr::extract_notes(pptx_path)
+    # Images
+    pdf_path <- gsplyr::download(link, type = "pdf")
+    image_path <- ptplyr::convert_pdf_png(pdf_path)
 
-  res <- ari::ari_spin(images = image_path,
-                       paragraphs = pptx_notes_vector,
-                       output = tmp_video,
-                       tts_engine_args =
-                         list(
-                           service = service,
-                           model_name = model_name,
-                           vocoder_name = vocoder_name))
+    ari::ari_spin(images = image_path,
+                  paragraphs = pptx_notes_vector,
+                  output = tmp_video,
+                  tts_engine_args =
+                    list(
+                      service = service,
+                      model_name = model_name,
+                      vocoder_name = vocoder_name))
+    # Read binary data from tmp_video as raw mode
+    readBin(tmp_video, "raw", n = file.info(tmp_video)$size)
   })
-
-  readBin(tmp_video, "raw", n = file.info(tmp_video)$size)
 }

--- a/inst/extdata/plumber.R
+++ b/inst/extdata/plumber.R
@@ -1,5 +1,7 @@
 # Packages ----
 library(plumber)
+library(future)
+plan(multisession, workers = 25)
 
 #* @apiTitle Loqui API
 #* @apiDescription A plumber API that generates automated videos from Google Slides or PowerPoint slides.
@@ -24,6 +26,7 @@ function(link, service, model_name, vocoder_name){
   # Temporary file
   tmp_video <- tempfile(fileext = ".mp4")
 
+  future::future({
   # Speaker Notes
   pptx_path <- gsplyr::download(link, type = "pptx")
   pptx_notes_vector <- ptplyr::extract_notes(pptx_path)
@@ -39,6 +42,7 @@ function(link, service, model_name, vocoder_name){
                            service = service,
                            model_name = model_name,
                            vocoder_name = vocoder_name))
+  })
 
   readBin(tmp_video, "raw", n = file.info(tmp_video)$size)
 }


### PR DESCRIPTION
## What I did

Use `future::future()` to launch multiple R sessions (workers) and offload the slow processing to the `future` worker sessions.

## How I tested

I tested this by drawing inspiration from this Posit Community [post](https://community.rstudio.com/t/future-with-plumber/94477/2). 

Here is what I did:

```
library(plumber)
pr("plumber.R") %>% pr_run(port = 8080)
```

Put some dummy inputs (`link`, `service`, `model_name`, `vocoder_name`) into the Swagger UI which will output a Request URL. For ex, `http://127.0.0.1:9854/generate_from_gs?link=https%3A%2F%2Fdocs.google.com%2Fpresentation%2Fd%2F1Dw_rBb1hySN_76xh9-x5J2dWF_das9BAUjQigf2fN-E%2Fedit%3Fusp%3Dsharing&service=coqui&model_name=jenny&vocoder_name=jenny`. 

Create a txt file with urls:

```
# From within terminal
cat > urls.txt << EOF
http://127.0.0.1:9854/generate_from_gs?link=https%3A%2F%2Fdocs.google.com%2Fpresentation%2Fd%2F1Dw_rBb1hySN_76xh9-x5J2dWF_das9BAUjQigf2fN-E%2Fedit%3Fusp%3Dsharing&service=coqui&model_name=jenny&vocoder_name=jenny
http://127.0.0.1:9854/generate_from_gs?link=https%3A%2F%2Fdocs.google.com%2Fpresentation%2Fd%2F1Dw_rBb1hySN_76xh9-x5J2dWF_das9BAUjQigf2fN-E%2Fedit%3Fusp%3Dsharing&service=coqui&model_name=jenny&vocoder_name=jenny
EOF
```

Code to test plumber:

```
# From within terminal
# Take all urls and execute curl in parallel with 2 workers
cat urls.txt | xargs -P 2 -n 1 curl
```


References:
- https://posit.co/resources/videos/plumber-and-future-async-web-apis/
- https://community.rstudio.com/t/future-with-plumber/94477/2